### PR TITLE
Add simple frontend for expense tracker

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Expense Tracker</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div id="auth">
+        <h2>Register</h2>
+        <form id="register-form">
+            <input type="text" id="reg-username" placeholder="Username" required>
+            <input type="password" id="reg-password" placeholder="Password" required>
+            <button type="submit">Register</button>
+        </form>
+        <h2>Login</h2>
+        <form id="login-form">
+            <input type="text" id="login-username" placeholder="Username" required>
+            <input type="password" id="login-password" placeholder="Password" required>
+            <button type="submit">Login</button>
+        </form>
+    </div>
+
+    <div id="app" class="hidden">
+        <h2>Add Expense</h2>
+        <form id="expense-form">
+            <input type="text" id="exp-description" placeholder="Description" required>
+            <input type="number" id="exp-amount" placeholder="Amount" required>
+            <input type="date" id="exp-date" required>
+            <input type="text" id="exp-category" placeholder="Category" required>
+            <button type="submit">Add</button>
+        </form>
+
+        <h2>Expenses</h2>
+        <table id="expenses-table">
+            <thead>
+                <tr>
+                    <th>Description</th>
+                    <th>Amount</th>
+                    <th>Date</th>
+                    <th>Category</th>
+                    <th>Actions</th>
+                </tr>
+            </thead>
+            <tbody></tbody>
+        </table>
+    </div>
+
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,156 @@
+const API_BASE = '/api';
+let token = localStorage.getItem('token');
+
+const authDiv = document.getElementById('auth');
+const appDiv = document.getElementById('app');
+const registerForm = document.getElementById('register-form');
+const loginForm = document.getElementById('login-form');
+const expenseForm = document.getElementById('expense-form');
+const expensesTable = document.querySelector('#expenses-table tbody');
+
+function showApp() {
+    authDiv.classList.add('hidden');
+    appDiv.classList.remove('hidden');
+    loadExpenses();
+}
+
+function showAuth() {
+    authDiv.classList.remove('hidden');
+    appDiv.classList.add('hidden');
+}
+
+async function registerUser(e) {
+    e.preventDefault();
+    const res = await fetch(`${API_BASE}/register`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+            username: document.getElementById('reg-username').value,
+            password: document.getElementById('reg-password').value
+        })
+    });
+    if (res.ok) {
+        alert('Registered! Please log in.');
+    } else {
+        alert('Register failed');
+    }
+}
+
+async function loginUser(e) {
+    e.preventDefault();
+    const res = await fetch(`${API_BASE}/login`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+            username: document.getElementById('login-username').value,
+            password: document.getElementById('login-password').value
+        })
+    });
+    if (res.ok) {
+        const data = await res.json();
+        token = data.token;
+        localStorage.setItem('token', token);
+        showApp();
+    } else {
+        alert('Login failed');
+    }
+}
+
+async function loadExpenses() {
+    const res = await fetch(`${API_BASE}/expenses`, {
+        headers: { Authorization: `Bearer ${token}` }
+    });
+    if (res.ok) {
+        const expenses = await res.json();
+        expensesTable.innerHTML = '';
+        expenses.forEach(addExpenseRow);
+    } else if (res.status === 401) {
+        showAuth();
+    }
+}
+
+function addExpenseRow(exp) {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `
+        <td><input data-id="${exp.id}" data-field="description" value="${exp.description}"></td>
+        <td><input data-id="${exp.id}" data-field="amount" type="number" value="${exp.amount}"></td>
+        <td><input data-id="${exp.id}" data-field="date" type="date" value="${exp.date.slice(0,10)}"></td>
+        <td><input data-id="${exp.id}" data-field="category" value="${exp.category}"></td>
+        <td>
+            <button data-action="save" data-id="${exp.id}">Save</button>
+            <button data-action="delete" data-id="${exp.id}">Delete</button>
+        </td>`;
+    expensesTable.appendChild(tr);
+}
+
+async function addExpense(e) {
+    e.preventDefault();
+    const res = await fetch(`${API_BASE}/expenses`, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${token}`
+        },
+        body: JSON.stringify({
+            description: document.getElementById('exp-description').value,
+            amount: parseFloat(document.getElementById('exp-amount').value),
+            date: document.getElementById('exp-date').value,
+            category: document.getElementById('exp-category').value
+        })
+    });
+    if (res.ok) {
+        const expense = await res.json();
+        addExpenseRow(expense);
+        expenseForm.reset();
+    } else {
+        alert('Failed to add expense');
+    }
+}
+
+async function updateExpense(id, data) {
+    const res = await fetch(`${API_BASE}/expenses/${id}`, {
+        method: 'PUT',
+        headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${token}`
+        },
+        body: JSON.stringify(data)
+    });
+    if (!res.ok) {
+        alert('Update failed');
+    }
+}
+
+async function deleteExpense(id) {
+    const res = await fetch(`${API_BASE}/expenses/${id}`, {
+        method: 'DELETE',
+        headers: { Authorization: `Bearer ${token}` }
+    });
+    if (res.ok) {
+        document.querySelectorAll(`[data-id="${id}"]`).forEach(el => el.closest('tr').remove());
+    } else {
+        alert('Delete failed');
+    }
+}
+
+registerForm.addEventListener('submit', registerUser);
+loginForm.addEventListener('submit', loginUser);
+expenseForm.addEventListener('submit', addExpense);
+
+expensesTable.addEventListener('click', e => {
+    if (e.target.dataset.action === 'delete') {
+        deleteExpense(e.target.dataset.id);
+    } else if (e.target.dataset.action === 'save') {
+        const id = e.target.dataset.id;
+        const row = e.target.closest('tr');
+        const data = {};
+        row.querySelectorAll('input').forEach(input => {
+            data[input.dataset.field] = input.value;
+        });
+        updateExpense(id, data);
+    }
+});
+
+if (token) {
+    showApp();
+}

--- a/style.css
+++ b/style.css
@@ -1,0 +1,31 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 20px;
+}
+
+.hidden {
+    display: none;
+}
+
+form {
+    margin-bottom: 20px;
+}
+
+input {
+    margin: 5px;
+}
+
+table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+th, td {
+    border: 1px solid #ccc;
+    padding: 8px;
+    text-align: left;
+}
+
+button {
+    padding: 5px 10px;
+}


### PR DESCRIPTION
## Summary
- create `index.html` with forms for registration, login and expense management
- style with `style.css`
- implement `script.js` to call backend APIs for auth and CRUD operations

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684b2e0f7f68832a8b01f0078fec5509